### PR TITLE
Fixing 2 bugs with gpg commands and fixing up script.

### DIFF
--- a/send-pgp-keys.sh
+++ b/send-pgp-keys.sh
@@ -4,18 +4,21 @@
 # LICENSE: WTFPL - https://github.com/jonathancross/jc-docs/blob/master/LICENSE
 
 ################################################################################
-# YOU MUST CHANGE THE SETTINGS BELOW BEFORE RUNNING
+# YOU MUST CHANGE THE SETTINGS BELOW BEFORE RUNNING                            #
 ################################################################################
 
-PGP_KEY=XXXXXXXXXXXXXXXX # Your 16 character PGP key handle. (required)
-GPG_COMMAND=gpg2         # GnuPG command to use: gpg or gpg2 (optional)
+GPG_ID=XXXXXXXXXXXXXXXX     # (required) Your 16 character GPG key ID without 0x
+GPG_ID_SHORT=${GPG_ID:8-16} # An 8 character short key ID.
+                            # You can optionally use this below as needed.
+GPG_COMMAND=gpg2            # GnuPG command to use: gpg or gpg2.
 
+# Configure the service(s) where you want to host your key.
 
-# Local backup of your key. (required)
+# Local export of your public key. (required)
 # Change this to match where you want the key backup stored:
-# Example: LOCAL_KEY_FILE=/tmp/${PGP_KEY}.asc
-# Example: LOCAL_KEY_FILE=~/Documents/${PGP_KEY}.asc
-LOCAL_KEY_FILE=~/${PGP_KEY}_pub.asc
+# Example: LOCAL_KEY_FILE=/tmp/${GPG_ID}.asc
+# Example: LOCAL_KEY_FILE=~/Documents/${GPG_ID_SHORT}.asc
+LOCAL_KEY_FILE=~/${GPG_ID}_pub.asc
 
 
 # Upload to one or more public key servers:
@@ -28,12 +31,14 @@ PUBLIC_KEY_SERVERS=(
 
 
 # Do you have a personal website where you want to upload your key?
+# This setting will upload your key using scp and the settings below.
 ENABLE_PERSONAL_KEY_SERVER=0 # Change to 1 (one) to enable.
 # scp login settings:
 PERSONAL_KEY_SERVER_USER=username           # Eg: jonathan
 PERSONAL_KEY_SERVER_DOMAIN=example.com      # Eg: example.com
-PERSONAL_KEY_SERVER_DEST_FOLDER=webroot/foo # Eg: folder name on remote server
-
+PERSONAL_KEY_SERVER_DEST_FOLDER=webroot/foo # Eg: folder name on remote server.
+                                            #     The LOCAL_KEY_FILE above will
+                                            #     be transferred there via scp.
 
 # Upload your key to Keybase?
 # Note: You must have an account on keybase.io and the `keybase` commandline
@@ -42,36 +47,36 @@ ENABLE_KEBASE=0 # Change to 1 (one) to enable.
 
 
 ################################################################################
-# DO NOT MODIFY BELOW THIS LINE
+# DO NOT MODIFY BELOW THIS LINE                                                #
 ################################################################################
 
 # Test config:
-if [[ "${PGP_KEY}" == "XXXXXXXXXXXXXXXX" ]]; then
-  echo "ERROR: Please configure this script with YOUR PGP Key handle."
+if [[ "${GPG_ID}" == "XXXXXXXXXXXXXXXX" ]]; then
+  echo "ERROR: Please configure this script with *YOUR* gpg Key ID."
 fi
 
 # Look at last time the key was exported:
-if [ -f ${LOCAL_KEY_FILE} ]; then
+if [[ -f ${LOCAL_KEY_FILE} ]]; then
   LASTMOD_DATE="$(ls -al ${LOCAL_KEY_FILE} | awk '{print $6,$7, $8}')"
 else
   LASTMOD_DATE='[first time]'
 fi
 
 echo "
-Publishing your key: ${PGP_KEY}
+Publishing your key: ${GPG_ID}
 "
 
 # Save the new public key to a file:
 echo " • Exporting key to file: ${LOCAL_KEY_FILE}"
 echo "   Last modified: ${LASTMOD_DATE}"
 
-# Grep for the key because gpg always returns true, even for missing keys:
-if ${GPG_COMMAND} --list-secret-keys --keyid-format=long | grep -q ${PGP_KEY}; then
-  ${GPG_COMMAND} --armor --export=${PGP_KEY} > ${LOCAL_KEY_FILE}
+# Confirm GPG_ID is correct:
+if ${GPG_COMMAND} --list-secret-keys ${GPG_ID} 2&>1 /dev/null; then
+  ${GPG_COMMAND} --armor --export ${GPG_ID} > ${LOCAL_KEY_FILE}
   LASTMOD_DATE="$(ls -al ${LOCAL_KEY_FILE} | awk '{print $6,$7, $8}')"
   echo "   Updated now:   ${LASTMOD_DATE}"
 else
-  echo " • ERROR: Could not export key ${PGP_KEY}.  Aborting."
+  echo " • ERROR: Could not export key ${GPG_ID}.  Aborting."
   exit 128
 fi
 
@@ -93,6 +98,6 @@ fi
 if [[ "${ENABLE_PUBLIC_KEY_SERVERS}" == "1" ]]; then
   for S in ${PUBLIC_KEY_SERVERS[@]};do
     printf " • ";
-    ${GPG_COMMAND} --keyid-format=long --send-key ${PGP_KEY} --keyserver ${S}
+    ${GPG_COMMAND} --keyid-format long --keyserver ${S} --send-key ${GPG_ID}
   done
 fi


### PR DESCRIPTION
Bugs fixed:
1. `gpg` does not accept parameters using equal sign (`=`), fails in strange ways.
2. `gpg` requires that `--send-key ${GPG_ID}` be _**last**_ when sending to keyserver.