### PR TITLE
ssh_tunnel_to_full_node.md : more hardening options

### DIFF
--- a/ssh_tunnel_to_full_node.md
+++ b/ssh_tunnel_to_full_node.md
@@ -119,6 +119,8 @@ AllowUsers my_normal_user sshtunnel
 # Restrict the sshtunnel user to only access Monero and Bitcoin node ports.
 Match User sshtunnel
   PermitOpen localhost:18081 localhost:8332
+  PermitListen none
+  PermitTTY no
   X11Forwarding no
   AllowAgentForwarding no
   ForceCommand /bin/false


### PR DESCRIPTION
Very nice guide. Two more hardening options for your consideration. They prevent 1) opening listening sockets on the server, e.g. with `ssh -R` and 2) allocation of a pseudoterminal device.